### PR TITLE
Bump GNOME version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "name": "Window demands attention shortcut",
   "shell-version": [
       "3.15.90",
-      "3.16"
+      "3.16",
+      "3.18"
   ],
   "url": "https://github.com/awamper/window-demands-attention-shortcut",
   "uuid": "window_demands_attention_shortcut@awamper.gmail.com",


### PR DESCRIPTION
Hi, the extension works like a charm in GNOME 3.18 – but the tweak tool won’t let me switch it on, unless `3.18` is explicitly listed in `metadata.json`.

Thanks for the great idea by the way!
